### PR TITLE
Include IReadOnlyCollection and IReadOnlyDictionary

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -3,8 +3,8 @@ const path = require('path');
 const flatten = arr => arr.reduce((a, b) => a.concat(b), []);
 
 const arrayRegex = /^(.+)\[\]$/;
-const simpleCollectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|HashSet)<([\w\d]+)>\??$/;
-const collectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|HashSet)<(.+)>\??$/;
+const simpleCollectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|IReadOnlyCollection|HashSet)<([\w\d]+)>\??$/;
+const collectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|IReadOnlyCollection|HashSet)<(.+)>\??$/;
 const simpleDictionaryRegex = /^(?:I?Dictionary|SortedDictionary)<([\w\d]+)\s*,\s*([\w\d]+)>\??$/;
 const dictionaryRegex = /^(?:I?Dictionary|SortedDictionary)<([\w\d]+)\s*,\s*(.+)>\??$/;
 

--- a/converter.js
+++ b/converter.js
@@ -5,8 +5,8 @@ const flatten = arr => arr.reduce((a, b) => a.concat(b), []);
 const arrayRegex = /^(.+)\[\]$/;
 const simpleCollectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|IReadOnlyCollection|HashSet)<([\w\d]+)>\??$/;
 const collectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|IReadOnlyCollection|HashSet)<(.+)>\??$/;
-const simpleDictionaryRegex = /^(?:I?Dictionary|SortedDictionary)<([\w\d]+)\s*,\s*([\w\d]+)>\??$/;
-const dictionaryRegex = /^(?:I?Dictionary|SortedDictionary)<([\w\d]+)\s*,\s*(.+)>\??$/;
+const simpleDictionaryRegex = /^(?:I?Dictionary|SortedDictionary|IReadOnlyDictionary)<([\w\d]+)\s*,\s*([\w\d]+)>\??$/;
+const dictionaryRegex = /^(?:I?Dictionary|SortedDictionary|IReadOnlyDictionary)<([\w\d]+)\s*,\s*(.+)>\??$/;
 
 const defaultTypeTranslations = {
     int: 'number',


### PR DESCRIPTION
This allows following conversions: 

```csharp
using System.Collections.Generic;

class Poco {
    public IReadOnlyCollection<int> Numbers { get; }
    public IReadOnlyDictionary<string, int> NumberPerKey { get; }
}
```

to

```ts
export interface Poco {
    Numbers: number[];
    NumbersPerKey: Record<string, number>;
}
```