### PR TITLE
Include descendant classes with no properties

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -66,7 +66,7 @@ const createConverter = config => {
         const members = [...model.Fields, ...model.Properties];
         const baseClasses = model.BaseClasses && model.BaseClasses.length ? ` extends ${model.BaseClasses.join(', ')}` : '';
 
-        if (members.length > 0 || model.IndexSignature) {
+        if (members.length >= 0 || model.IndexSignature) {
             rows.push(`// ${filename}`);
             rows.push(`export interface ${model.ModelName}${baseClasses} {`);
 


### PR DESCRIPTION
Including descendant classes with no properties explicitly defined, to be part of the generated definitions.
It might seem odd, but there are scenarios where due to logical (not practical) reasons, such classes exist.