### PR TITLE
Use 'sindresorhus/camelcase' package for case conversions

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const camelcase = require('camelcase');
 
 const flatten = arr => arr.reduce((a, b) => a.concat(b), []);
 
@@ -89,7 +90,7 @@ const createConverter = config => {
         const entries = Object.entries(enum_.Values);
 
         const getEnumStringValue = (value) => config.camelCaseEnums
-            ? value[0].toLowerCase() + value.substring(1)
+            ? camelcase(value)
             : value;
 
         if (config.stringLiteralTypesInsteadOfEnums) {
@@ -170,7 +171,7 @@ const createConverter = config => {
         return array ? `${type}[]` : type;
     };
 
-    const convertIdentifier = identifier => config.camelCase ? identifier[0].toLowerCase() + identifier.substring(1) : identifier;
+    const convertIdentifier = identifier => config.camelCase ? camelcase(identifier) : identifier;
     const convertType = type => type in typeTranslations ? typeTranslations[type] : type;
 
     return convert;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "csharp-models-to-typescript",
   "version": "0.18.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "camelcase": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+      "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "bin": {
     "csharp-models-to-typescript": "./index.js"
+  },
+  "dependencies": {
+    "camelcase": "^6.0.0"
   }
 }


### PR DESCRIPTION
Fixes incorrect camel case conversion for property names like: FOOBar.

Expected result: fooBar
Actual result: fOOBar