### PR TITLE
Force custom translation if any before parse checks

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -147,6 +147,10 @@ const createConverter = config => {
     };
 
     const parseType = propType => {
+        if(propType in typeTranslations) {
+            return convertType(propType);
+        }
+
         const array = propType.match(arrayRegex);
         if (array) {
             propType = array[1];


### PR DESCRIPTION
Force the custom translation defined by the user before perfoming other checks.

There are some problems when the user tries to custom translate an C# Array to a javascript type.
I've trying to custom translate `byte[]` to `string`, but it ended up translating it to `string[]`.

I had similar problems trying to translate `Model[]` to `AnotherModel[]`.
My config-file.json at "customTypeTranslations" was sometinh like this:
```
{
  "byte[]": "string",
  "Model[]": "AnotherModel[]"
}
```