### PR TITLE
fix bug: unspecified .NET framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const converter = createConverter({
 let timer = process.hrtime();
 
 const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');
-const dotnetProcess = spawn('dotnet', ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`], { shell: true });
+const dotnetProcess = spawn('dotnet', ['run', `--project "${dotnetProject}"`, ...(config.framework && [`--framework "${config.framework}"`] || []), `"${path.resolve(configPath)}"`], { shell: true });
 
 let stdout = '';
 


### PR DESCRIPTION
Allows the user to specify the .NET framework in the config file. Fix a bug where the dotnet command throws an error message: "Your project targets multiple frameworks. Please specify which framework to run using '--framework'"