### PR TITLE
Lowering first letters without losing underscore in order to be compatible with C# Web Api and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ npm install --save csharp-models-to-typescript
     "namespace": "Api",
     "output": "./api.d.ts",
     "camelCase": false,
+    "lowerFirstLetter": false,
     "camelCaseEnums": false,
     "camelCaseOptions": {
         "pascalCase": false,
@@ -58,6 +59,17 @@ $ npm install --save csharp-models-to-typescript
 ```
 
 3. Run the npm script `generate-types` and the output file specified in your config should be created and populated with your models.
+
+## Configure Config File
+
+**camelCase** makes the attributes camel case, using **camelCaseOptions**. npm camelcase package is used for this purpose.
+**output** is the location for output
+**namespace** is the namespace for the generated files
+**include** are the locations for the input files
+**exclude** are files that are excluded
+**lowerFirstLetter** lowers the first letter of attributes, if they are starting with an upper letter and continues with a lower one.
+
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install --save csharp-models-to-typescript
     "namespace": "Api",
     "output": "./api.d.ts",
     "camelCase": false,
-    "lowerFirstLetter": false,
+    "lowerFirstLetters": false,
     "camelCaseEnums": false,
     "camelCaseOptions": {
         "pascalCase": false,
@@ -67,7 +67,7 @@ $ npm install --save csharp-models-to-typescript
 **namespace** is the namespace for the generated files
 **include** are the locations for the input files
 **exclude** are files that are excluded
-**lowerFirstLetter** lowers the first letter of attributes, if they are starting with an upper letter and continues with a lower one.
+**lowerFirstLetters** lowers the first letters of attributes. ID => id MYLocation => myLocation
 
 
 

--- a/converter.js
+++ b/converter.js
@@ -125,7 +125,7 @@ const createConverter = config => {
 
     const convertProperty = property => {
         const optional = property.Type.endsWith('?');
-        const identifier = convertIdentifier(optional ? `${property.Identifier.split(' ')[0]}?` : property.Identifier.split(' ')[0]);
+        const identifier = convertIdentifier(optional ? `${property.Identifier.split(/[ =]+/)[0]}?` : property.Identifier.split(/[ =]+/)[0]);
 
         const type = parseType(property.Type);
 
@@ -175,7 +175,16 @@ const createConverter = config => {
         return array ? `${type}[]` : type;
     };
 
-    const convertIdentifier = identifier => config.camelCase ? camelcase(identifier, config.camelCaseOptions) : identifier;
+    const convertIdentifier = identifier => {
+        identifier = config.lowerFirstLetter ? lowerFirstLetter(identifier) : identifier;
+        return config.camelCase ? camelcase(identifier, config.camelCaseOptions) : identifier;
+    }
+    const lowerFirstLetter = str => {
+        if(str.length===1) return str.toLowerCase();
+        if(str[0].toUpperCase()===str[0] && str[1].toLowerCase() ===str[1])
+            return str.slice(0, 1).toLowerCase() + str.slice(1);
+        return str;
+    }
     const convertType = type => type in typeTranslations ? typeTranslations[type] : type;
 
     return convert;

--- a/converter.js
+++ b/converter.js
@@ -176,14 +176,17 @@ const createConverter = config => {
     };
 
     const convertIdentifier = identifier => {
-        identifier = config.lowerFirstLetter ? lowerFirstLetter(identifier) : identifier;
+        identifier = config.lowerFirstLetters ? lowerFirstLetters(identifier) : identifier;
         return config.camelCase ? camelcase(identifier, config.camelCaseOptions) : identifier;
     }
-    const lowerFirstLetter = str => {
-        if(str.length===1) return str.toLowerCase();
-        if(str[0].toUpperCase()===str[0] && str[1].toLowerCase() ===str[1])
-            return str.slice(0, 1).toLowerCase() + str.slice(1);
-        return str;
+    const lowerFirstLetters = str => {
+        let i = 0;
+        while (i < str.length && str[i].toUpperCase() === str[i] && str[i] !== "_") {
+          i++;
+        }
+        if(i>1) 
+            i = i-1; // if it has only one upper letter, it will be lowered, but if it has more than one upper letter, the last one may be start of another string
+        return str.slice(0, i).toLowerCase() + str.slice(i);
     }
     const convertType = type => type in typeTranslations ? typeTranslations[type] : type;
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const output = config.output || 'types.d.ts';
 const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},
     namespace: config.namespace,
+    lowerFirstLetter: config.lowerFirstLetter,
     camelCase: config.camelCase || false,
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const output = config.output || 'types.d.ts';
 const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},
     namespace: config.namespace,
-    lowerFirstLetter: config.lowerFirstLetter,
+    lowerFirstLetters: config.lowerFirstLetters,
     camelCase: config.camelCase || false,
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,


### PR DESCRIPTION
I checked a web api about what it returns for various objects. So as I see, underscores are saved, but the initial letters are lowercase if they are uppercase in the backend. So I added a config, which will let you have the same object with the one that returns from web api 