### PR TITLE
Retarget to .NET 6

### DIFF
--- a/lib/csharp-models-to-json/csharp-models-to-json.csproj
+++ b/lib/csharp-models-to-json/csharp-models-to-json.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
+++ b/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.1" />


### PR DESCRIPTION
.NET 3.1 causes crash because lost support and was deleted in some environments.

Moving .NET projects to .NET 6 (latest LTS)