### PR TITLE
dotnet EOL warning suppression

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,13 @@ const converter = createConverter({
 let timer = process.hrtime();
 
 const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');
-const dotnetProcess = spawn('dotnet', ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`], { shell: true });
+
+let processParamaters = ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`];
+if(config.suppressEolFrameworkErrors){
+    processParamaters.push('--property:CheckEolTargetFramework=false');
+}
+
+const dotnetProcess = spawn('dotnet', processParameters, { shell: true });
 
 let stdout = '';
 

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ let timer = process.hrtime();
 
 const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');
 
-let processParamaters = ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`];
-if(config.suppressEolFrameworkErrors){
+let processParameters = ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`];
+if (config.suppressEolFrameworkErrors){
     processParamaters.push('--property:CheckEolTargetFramework=false');
 }
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');
 
 let processParameters = ['run', `--project "${dotnetProject}"`, `"${path.resolve(configPath)}"`];
 if (config.suppressEolFrameworkErrors){
-    processParamaters.push('--property:CheckEolTargetFramework=false');
+    processParameters.push('--property:CheckEolTargetFramework=false');
 }
 
 const dotnetProcess = spawn('dotnet', processParameters, { shell: true });


### PR DESCRIPTION
Adding a property to the dotnet run process that will suppress EOL Framework warnings based on the bool from the config.

When using the package on older frameworks, the dotnet run process; rightly, displays that the framework being used has reached EOL. This however means that the JSON generated is invalid as it contains warnings IE:

C:\dotnet\sdk\7.0.202\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [C:\path\to\the\node_modules\csharp-models-to-typescript\lib\csharp-models-to-json\csharp-models-to-json.csproj]
[{foo:bar}]

Which when ran through JSON.parse; index.js: 70, errors with "Unexpected token C in JSON at position 0". 

Adding this additional parameter on the config; suppressEolFrameworkErrors, suppresses those EOL warnings and only the generated JSON is sent for parsing.