### PR TITLE
Ignore IgnoreDataMember attribute

### DIFF
--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -87,7 +87,8 @@ namespace CSharpModelsToJson
         private static bool IsIgnored(SyntaxList<AttributeListSyntax> propertyAttributeLists) => 
             propertyAttributeLists.Any(attributeList => 
                 attributeList.Attributes.Any(attribute => 
-                    attribute.Name.ToString().Equals("JsonIgnore")));
+                    attribute.Name.ToString().Equals("JsonIgnore") ||
+                    attribute.Name.ToString().Equals("IgnoreDataMember")));
 
         private static bool IsAccessible(SyntaxTokenList modifiers) => modifiers.All(modifier =>
             modifier.ToString() != "const" &&

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -141,6 +141,9 @@ namespace CSharpModelsToJson.Tests
                     [JsonIgnore]
                     public string Ignored { get; set; }
 
+                    [IgnoreDataMember]
+                    public string Ignored2 { get; set; }
+
                     public void AMember() 
                     { 
                     }


### PR DESCRIPTION
The project is ignoring according to `JsonIgnore` attribute. But the attribute `IgnoreDataMember` used by WCF can be present too.
