### PR TITLE
Validate enum binary value

### DIFF
--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -24,10 +24,7 @@ namespace CSharpModelsToJson
                     ? member.EqualsValue.Value.ToString()
                     : null;
 
-                if (value?.StartsWith("0b") == true)
-                    value = value.Replace("_", "");
-
-                values[member.Identifier.ToString()] = value;
+                values[member.Identifier.ToString()] = value?.Replace("_", "");
             }
 
             this.Enums.Add(new Enum() {

--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -5,13 +5,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
  
 namespace CSharpModelsToJson
 {
-    class Enum
+    public class Enum
     {
         public string Identifier { get; set; }
         public Dictionary<string, object> Values { get; set; }
     }
 
-    class EnumCollector: CSharpSyntaxWalker
+    public class EnumCollector: CSharpSyntaxWalker
     {
         public readonly List<Enum> Enums = new List<Enum>();
 
@@ -20,9 +20,14 @@ namespace CSharpModelsToJson
             var values = new Dictionary<string, object>();
 
             foreach (var member in node.Members) {
-                values[member.Identifier.ToString()] = member.EqualsValue != null
+                var value = member.EqualsValue != null
                     ? member.EqualsValue.Value.ToString()
                     : null;
+
+                if (value?.StartsWith("0b") == true)
+                    value = value.Replace("_", "");
+
+                values[member.Identifier.ToString()] = value;
             }
 
             this.Enums.Add(new Enum() {

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -177,10 +177,13 @@ namespace CSharpModelsToJson.Tests
         public void EnumBinaryValue()
         {
             var tree = CSharpSyntaxTree.ParseText(@"
-                public enum A
-                {
-                    A = 0b_0000_0001,
-                    B = 0b00000010,
+                public enum A {
+                    A = 1,              // decimal: 1
+                    B = 1_002,          // decimal: 1002
+                    C = 0b011,          // binary: 3 in decimal
+                    D = 0b_0000_0100,   // binary: 4 in decimal
+                    E = 0x005,          // hexadecimal: 5 in decimal
+                    F = 0x000_01a,      // hexadecimal: 26 in decimal
                 }"
             );
 
@@ -191,11 +194,15 @@ namespace CSharpModelsToJson.Tests
 
             var model = enumCollector.Enums.First();
 
-            Assert.IsNotNull(model);
-            Assert.IsNotNull(model.Values);
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.Values, Is.Not.Null);
 
-            Assert.AreEqual("0b00000001", model.Values["A"]);
-            Assert.AreEqual("0b00000010", model.Values["B"]);
+            Assert.That(model.Values["A"], Is.EqualTo("1"));
+            Assert.That(model.Values["B"], Is.EqualTo("1002"));
+            Assert.That(model.Values["C"], Is.EqualTo("0b011"));
+            Assert.That(model.Values["D"], Is.EqualTo("0b00000100"));
+            Assert.That(model.Values["E"], Is.EqualTo("0x005"));
+            Assert.That(model.Values["F"], Is.EqualTo("0x00001a"));
         }
 
     }

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -172,5 +172,31 @@ namespace CSharpModelsToJson.Tests
             Assert.That(modelCollector.Models.First().BaseClasses, Is.Not.Null);
             Assert.That(modelCollector.Models.First().BaseClasses, Is.EqualTo(new[] { "Dictionary<string, string>" }));
         }
+
+        [Test]
+        public void EnumBinaryValue()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public enum A
+                {
+                    A = 0b_0000_0001,
+                    B = 0b00000010,
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+
+            var enumCollector = new EnumCollector();
+            enumCollector.VisitEnumDeclaration(root.DescendantNodes().OfType<EnumDeclarationSyntax>().First());
+
+            var model = enumCollector.Enums.First();
+
+            Assert.IsNotNull(model);
+            Assert.IsNotNull(model.Values);
+
+            Assert.AreEqual("0b00000001", model.Values["A"]);
+            Assert.AreEqual("0b00000010", model.Values["B"]);
+        }
+
     }
 }

--- a/test-files/TestClass.cs
+++ b/test-files/TestClass.cs
@@ -21,4 +21,13 @@ namespace TestClass
 
         public bool BooleanProperty { get; set; }
     }
+
+    public enum TestEnum {
+        A = 1,              // decimal: 1
+        B = 1_002,          // decimal: 1002
+        C = 0b011,          // binary: 3 in decimal
+        D = 0b_0000_0100,   // binary: 4 in decimal
+        E = 0x005,          // hexadecimal: 5 in decimal
+        F = 0x000_01a,      // hexadecimal: 26 in decimal
+    }
 }


### PR DESCRIPTION
Javascript do not have underline character separating values.