### PR TITLE
Upgrade .NET dependencies (Retarget to .NET 8) and use System.Text.Json

### DIFF
--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using Ganss.IO;
 
 namespace CSharpModelsToJson
@@ -35,7 +35,7 @@ namespace CSharpModelsToJson
                 files.Add(parseFile(fileName));
             }
 
-            string json = JsonConvert.SerializeObject(files);
+            string json = JsonSerializer.Serialize(files);
             System.Console.WriteLine(json);
         }
 

--- a/lib/csharp-models-to-json/csharp-models-to-json.csproj
+++ b/lib/csharp-models-to-json/csharp-models-to-json.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Glob.cs" Version="5.0.224" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Glob.cs" Version="5.1.1491" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -25,8 +25,8 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.AreEqual(new[] { "B", "C", "D" }, modelCollector.Models.First().BaseClasses);
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().BaseClasses, Is.EqualTo(new[] { "B", "C", "D" }));
         }
 
         [Test]
@@ -67,9 +67,9 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.Visit(root);
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.AreEqual(3, modelCollector.Models.Count);
-            Assert.AreEqual(3, modelCollector.Models.First().Properties.Count());
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.Count, Is.EqualTo(3));
+            Assert.That(modelCollector.Models.First().Properties.Count(), Is.EqualTo(3));
         }
 
 
@@ -90,8 +90,8 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.AreEqual(new[] { "IController<Controller>" }, modelCollector.Models.First().BaseClasses);
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().BaseClasses, Is.EqualTo(new[] { "IController<Controller>" }));
         }
 
         [Test]
@@ -119,9 +119,9 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.IsNotNull(modelCollector.Models.First().Properties);
-            Assert.AreEqual(1, modelCollector.Models.First().Properties.Count());
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().Properties, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().Properties.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -152,9 +152,10 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.IsNotNull(modelCollector.Models.First().Properties);
-            Assert.AreEqual(1, modelCollector.Models.First().Properties.Count());
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().Properties, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().Properties.Count(), Is.EqualTo(1));
+
         }
 
         [Test]
@@ -167,9 +168,9 @@ namespace CSharpModelsToJson.Tests
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
 
-            Assert.IsNotNull(modelCollector.Models);
-            Assert.IsNotNull(modelCollector.Models.First().BaseClasses);
-            Assert.AreEqual(new[] { "Dictionary<string, string>" }, modelCollector.Models.First().BaseClasses);
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().BaseClasses, Is.Not.Null);
+            Assert.That(modelCollector.Models.First().BaseClasses, Is.EqualTo(new[] { "Dictionary<string, string>" }));
         }
     }
 }

--- a/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
+++ b/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit" Version="3.10.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\csharp-models-to-json\csharp-models-to-json.csproj">


### PR DESCRIPTION
Upgrade .NET dependencies (Retarget to .NET 8) and replace Newtonsoft.Json with System.Text.Json (also fixes #73)
- .NET Core 3.1 is out of support and causes crash

@svenheden hope you'll like this.