### PR TITLE
Keep C# enum value sequence

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -113,9 +113,13 @@ const createConverter = config => {
         } else {
             rows.push(`export enum ${enum_.Identifier} {`);
 
-            entries.forEach(([key, value], i) => {
+            entries.forEach(([key, value]) => {
                 if (config.numericEnums) {
-                    rows.push(`    ${key} = ${value != null ? value : i},`);
+                    if (value == null) {
+                        rows.push(`    ${key},`);
+                    } else {
+                        rows.push(`    ${key} = ${value},`);
+                    }
                 } else {
                     rows.push(`    ${key} = '${getEnumStringValue(key)}',`);
                 }

--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -5,13 +5,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
  
 namespace CSharpModelsToJson
 {
-    class Enum
+    public class Enum
     {
         public string Identifier { get; set; }
         public Dictionary<string, object> Values { get; set; }
     }
 
-    class EnumCollector: CSharpSyntaxWalker
+    public class EnumCollector: CSharpSyntaxWalker
     {
         public readonly List<Enum> Enums = new List<Enum>();
 

--- a/lib/csharp-models-to-json_test/EnumCollector_test.cs
+++ b/lib/csharp-models-to-json_test/EnumCollector_test.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+
+namespace CSharpModelsToJson.Tests
+{
+    [TestFixture]
+    public class EnumCollectorTest
+    {
+        [Test]
+        public void ReturnEnumWithMissingValues()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public enum SampleEnum
+                {
+                   A,
+                   B = 7,
+                   C,
+                   D = 4,
+                   E
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+
+            var enumCollector = new EnumCollector();
+            enumCollector.VisitEnumDeclaration(root.DescendantNodes().OfType<EnumDeclarationSyntax>().First());
+
+            var model = enumCollector.Enums.First();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.Values, Is.Not.Null);
+
+            var values = model.Values.ToArray();
+            Assert.That(values[0].Value, Is.Null);
+            Assert.That(values[1].Value, Is.EqualTo("7"));
+            Assert.That(values[2].Value, Is.Null);
+            Assert.That(values[3].Value, Is.EqualTo("4"));
+            Assert.That(values[4].Value, Is.Null);
+        }
+    }
+}

--- a/test-files/TestFile.cs
+++ b/test-files/TestFile.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 
-namespace TestClass
+namespace TestNamespace
 {
     /// <summary>
     /// Sample class comment.
@@ -29,5 +29,6 @@ namespace TestClass
         D = 0b_0000_0100,   // binary: 4 in decimal
         E = 0x005,          // hexadecimal: 5 in decimal
         F = 0x000_01a,      // hexadecimal: 26 in decimal
+        G                   // 27 in decimal
     }
 }


### PR DESCRIPTION
As I could test, TypeScript folow the same C# numbering sequence when enum value is missing in declaring type.
I think that if no number is defined in C#, it could remains not defined in TypeScript.
@svenheden and @SafeerH, any idea of problems we might have with this change?

**C#:** https://sharplab.io/#v2:CYLg1APgAgzABAUwHYFcC2cBCBLANr7JAcwGEBPAY1wQFgAoAb3rhYEEAaZlzOAXjgDsnOizglhogCJ84AFgksAovQC+QA==
**TypeScript:** https://www.typescriptlang.org/play/?#code/KYOwrgtgBAQglgGwXEBzAwgTwMYOAKAG98pSBBAGhNJigF4oB2K0qdF0gEXqgBYOoAUXwBfIA

Closes #29 