### PR TITLE
Added Directory.Build files to isolate cs projects

### DIFF
--- a/lib/Directory.Build.props
+++ b/lib/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+  </PropertyGroup>
+</Project>

--- a/lib/Directory.Build.targets
+++ b/lib/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
If you use the node package in a project that has a Directory.Build.props or Directory.build.targets file in its root, the settings in those files control the compilation of the packages c# code. For instance, if nullable is enabled for the solution using the package, the csproj files will fail to build as they aren't nullable aware.