### PR TITLE
Use JsonSerializer instead of ConfigurationBuilder to allow for case-sensitive values in configuration

### DIFF
--- a/lib/csharp-models-to-json/Config.cs
+++ b/lib/csharp-models-to-json/Config.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace CSharpModelsToJson
+{
+    public class Config
+    {
+        public List<string> Include { get; set; }
+        public List<string> Exclude { get; set; }
+    }
+}

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -22,11 +22,11 @@ namespace CSharpModelsToJson
         {
             Config? config = null;
             if (System.IO.File.Exists(args[0])) {
-                var json = System.IO.File.ReadAllText(args[0]);
+                var configJson = System.IO.File.ReadAllText(args[0]);
                 var opts = new JsonSerializerOptions {
                     PropertyNameCaseInsensitive = true
                 };
-                config = JsonSerializer.Deserialize<Config>(json, opts);
+                config = JsonSerializer.Deserialize<Config>(configJson, opts);
             }
 
             var includes = config?.Include ?? [];

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -22,9 +22,11 @@ namespace CSharpModelsToJson
         {
             Config? config = null;
             if (System.IO.File.Exists(args[0])) {
-                config = JsonSerializer.Deserialize<Config>(System.IO.File.ReadAllText(args[0]), new JsonSerializerOptions {
+                var json = System.IO.File.ReadAllText(args[0]);
+                var opts = new JsonSerializerOptions {
                     PropertyNameCaseInsensitive = true
-                });
+                };
+                config = JsonSerializer.Deserialize<Config>(json, opts);
             }
 
             var includes = config?.Include ?? [];

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -20,10 +20,15 @@ namespace CSharpModelsToJson
     {
         static void Main(string[] args)
         {
-            var config = JsonSerializer.Deserialize<Config>(System.IO.File.ReadAllText(args[0]));
+            Config? config = null;
+            if (System.IO.File.Exists(args[0])) {
+                config = JsonSerializer.Deserialize<Config>(System.IO.File.ReadAllText(args[0]), new JsonSerializerOptions {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
 
-            var includes = config.Include ?? [];
-            var excludes = config.Exclude ?? [];
+            var includes = config?.Include ?? [];
+            var excludes = config?.Exclude ?? [];
 
             List<File> files = new List<File>();
 

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -5,7 +5,6 @@ using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Configuration;
 using Ganss.IO;
 
 namespace CSharpModelsToJson
@@ -21,15 +20,10 @@ namespace CSharpModelsToJson
     {
         static void Main(string[] args)
         {
-            IConfiguration config = new ConfigurationBuilder()
-                .AddJsonFile(args[0], true, true)
-                .Build();
+            var config = JsonSerializer.Deserialize<Config>(System.IO.File.ReadAllText(args[0]));
 
-            List<string> includes = new List<string>();
-            List<string> excludes = new List<string>();
-
-            config.Bind("include", includes);
-            config.Bind("exclude", excludes);
+            var includes = config.Include ?? [];
+            var excludes = config.Exclude ?? [];
 
             List<File> files = new List<File>();
 

--- a/lib/csharp-models-to-json/csharp-models-to-json.csproj
+++ b/lib/csharp-models-to-json/csharp-models-to-json.csproj
@@ -8,9 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Glob.cs" Version="5.1.1491" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csharp-models-to-typescript",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "title": "C# models to TypeScript",
   "author": "Jonathan Svenheden <jonathan@svenheden.com>",
   "license": "MIT",


### PR DESCRIPTION
Latest master currently uses this code to parse `.json` config file:

https://github.com/svenheden/csharp-models-to-typescript/blob/39fd1e492a27cd78483664fd901e259401c2d3aa/lib/csharp-models-to-json/Program.cs#L24-L32

Said config file contains config values for both C#-part (`include` and `exclude`) as well as JS-part (every other option).

Code in `Microsoft.Extensions.Configuration.Json` is [hardcoded](https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs#L16) to be case-insensitive, thus disallowing configuration like:
```json
{
  "FOO": 42,
  "foo": 43
}
```

Unfortunately this is exactly what I need in my project - we have a legacy `UUId` type and a modern `Uuid` type, that both needs to be translated to `string` in TypeScript.

Using regular `System.Text.Json.JsonSerializer` allows handling this case